### PR TITLE
Switching to AWS SDK v2, Java 8

### DIFF
--- a/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbDeploymentContextConfigurationSource.java
+++ b/archaius-aws/src/main/java/com/netflix/config/sources/DynamoDbDeploymentContextConfigurationSource.java
@@ -16,7 +16,6 @@
 package com.netflix.config.sources;
 
 import com.netflix.config.*;
-import org.apache.commons.configuration.AbstractConfiguration;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoBackedConfigurationIntegrationTest.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoBackedConfigurationIntegrationTest.java
@@ -15,19 +15,14 @@
  */
 package com.netflix.config.sources;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
-
-import static com.netflix.config.sources.DynamoDbIntegrationTestHelper.*;
-
 import com.netflix.config.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
-
-
+import static com.netflix.config.sources.DynamoDbIntegrationTestHelper.*;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -36,12 +31,12 @@ import static org.junit.Assert.assertEquals;
  */
 public class DynamoBackedConfigurationIntegrationTest {
     private static final String tableName = DynamoDbConfigurationSource.defaultTable + "UNITTEST";
-    private static AmazonDynamoDB dbClient;
+    private static DynamoDbClient dbClient;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
         try {
-            dbClient = new AmazonDynamoDBClient(new DefaultAWSCredentialsProviderChain().getCredentials());
+            dbClient = DynamoDbClient.builder().credentialsProvider(DefaultCredentialsProvider.create()).build();
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -57,7 +52,7 @@ public class DynamoBackedConfigurationIntegrationTest {
         if (dbClient != null) removeTable(dbClient, tableName);
     }
 
-    //@Test
+    // @Test // disabled as it requires additional setup
     public void testPropertyChange() throws Exception{
         System.setProperty("com.netflix.config.dynamo.tableName", tableName);
         if (dbClient != null) {

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoBackedConfigurationTest.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoBackedConfigurationTest.java
@@ -15,10 +15,10 @@
  */
 package com.netflix.config.sources;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.netflix.config.*;
 import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.*;
 public class DynamoBackedConfigurationTest {
     @Test
     public void testPropertyChange() throws Exception {
-        AmazonDynamoDB mockBasicDbClient = mock(AmazonDynamoDB.class);
+        DynamoDbClient mockBasicDbClient = mock(DynamoDbClient.class);
 
         //3 of the first config to cover: object creation, threadRun at 0 delay, load properties
         when(mockBasicDbClient.scan(any(ScanRequest.class))).thenReturn(DynamoDbMocks.basicScanResult1,

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbConfigurationSourceIntegrationTest.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbConfigurationSourceIntegrationTest.java
@@ -15,17 +15,15 @@
  */
 package com.netflix.config.sources;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.netflix.config.PollResult;
-
-import static com.netflix.config.sources.DynamoDbIntegrationTestHelper.*;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import static com.netflix.config.sources.DynamoDbIntegrationTestHelper.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * User: gorzell
@@ -33,12 +31,12 @@ import org.junit.Test;
  */
 public class DynamoDbConfigurationSourceIntegrationTest {
     private static final String tableName = DynamoDbConfigurationSource.defaultTable + "UNITTEST";
-    private static AmazonDynamoDB dbClient;
+    private static DynamoDbClient dbClient;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
         try {
-            dbClient = new AmazonDynamoDBClient(new DefaultAWSCredentialsProviderChain().getCredentials());
+            dbClient = DynamoDbClient.builder().credentialsProvider(DefaultCredentialsProvider.create()).build();
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -54,10 +52,10 @@ public class DynamoDbConfigurationSourceIntegrationTest {
         if (dbClient != null) removeTable(dbClient, tableName);
     }
 
-    //@Test
+    // @Test // disabled as it requires additional setup
     public void testPoll() throws Exception {
         if (dbClient != null) {
-            DynamoDbConfigurationSource testConfigSource = new DynamoDbConfigurationSource();
+            DynamoDbConfigurationSource testConfigSource = new DynamoDbConfigurationSource(dbClient);
             PollResult result = testConfigSource.poll(true, null);
             assertEquals(3, result.getComplete().size());
             assertEquals("val1", result.getComplete().get("test1"));
@@ -66,10 +64,10 @@ public class DynamoDbConfigurationSourceIntegrationTest {
         }
     }
 
-    //@Test
+    // @Test // disabled as it requires additional setup
     public void testUpdate() throws Exception {
         if (dbClient != null) {
-            DynamoDbConfigurationSource testConfigSource = new DynamoDbConfigurationSource();
+            DynamoDbConfigurationSource testConfigSource = new DynamoDbConfigurationSource(dbClient);
 
             PollResult result = testConfigSource.poll(true, null);
             assertEquals(3, result.getComplete().size());

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbConfigurationSourceTest.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbConfigurationSourceTest.java
@@ -15,13 +15,10 @@
  */
 package com.netflix.config.sources;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.model.ScanRequest;
-import com.netflix.config.ConfigurationManager;
 import com.netflix.config.PollResult;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
@@ -36,7 +33,7 @@ public class DynamoDbConfigurationSourceTest {
 
     @Test
     public void testPoll() throws Exception {
-        AmazonDynamoDB mockBasicDbClient = mock(AmazonDynamoDB.class);
+        DynamoDbClient mockBasicDbClient = mock(DynamoDbClient.class);
         when(mockBasicDbClient.scan(any(ScanRequest.class))).thenReturn(DynamoDbMocks.basicScanResult1);
 
         DynamoDbConfigurationSource testConfigSource = new DynamoDbConfigurationSource(mockBasicDbClient);
@@ -49,7 +46,7 @@ public class DynamoDbConfigurationSourceTest {
 
     @Test
     public void testUpdate() throws Exception {
-        AmazonDynamoDB mockBasicDbClient = mock(AmazonDynamoDB.class);
+        DynamoDbClient mockBasicDbClient = mock(DynamoDbClient.class);
         when(mockBasicDbClient.scan(any(ScanRequest.class))).thenReturn(DynamoDbMocks.basicScanResult1, DynamoDbMocks.basicScanResult2);
 
         DynamoDbConfigurationSource testConfigSource = new DynamoDbConfigurationSource(mockBasicDbClient);

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbDeploymentContextConfigurationSourceTest.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbDeploymentContextConfigurationSourceTest.java
@@ -15,22 +15,17 @@
  */
 package com.netflix.config.sources;
 
-import com.netflix.config.ConfigurationBasedDeploymentContext;
-import com.netflix.config.ConfigurationManager;
-import com.netflix.config.DeploymentContext;
-import com.netflix.config.PollResult;
-import com.netflix.config.PropertyWithDeploymentContext;
+import com.netflix.config.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * User: gorzell

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbDeploymentContextTableCacheTest.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbDeploymentContextTableCacheTest.java
@@ -15,11 +15,11 @@
  */
 package com.netflix.config.sources;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.netflix.config.DeploymentContext;
 import com.netflix.config.PropertyWithDeploymentContext;
 import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 
 import java.util.Collection;
 
@@ -55,7 +55,7 @@ public class DynamoDbDeploymentContextTableCacheTest {
 
     @Test
     public void testPoll() throws Exception {
-        AmazonDynamoDB mockContextDbClient = mock(AmazonDynamoDB.class);
+        DynamoDbClient mockContextDbClient = mock(DynamoDbClient.class);
 
         when(mockContextDbClient.scan(any(ScanRequest.class))).thenReturn(DynamoDbMocks.contextScanResult1,
                 DynamoDbMocks.contextScanResult2);

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbIntegrationTestHelper.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbIntegrationTestHelper.java
@@ -15,8 +15,8 @@
  */
 package com.netflix.config.sources;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.model.*;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,85 +25,85 @@ import java.util.Map;
 
 public class DynamoDbIntegrationTestHelper {
 
-    static void createTable(AmazonDynamoDB dbClient, String tableName) throws InterruptedException {
+    static void createTable(DynamoDbClient dbClient, String tableName) throws InterruptedException {
         //TODO check to make sure the table isn't being created or deleted.
-        KeySchemaElement hashKey = new KeySchemaElement()
-                .withAttributeName(DynamoDbConfigurationSource.defaultKeyAttribute).withKeyType(KeyType.HASH);
+        KeySchemaElement hashKey = KeySchemaElement.builder()
+                .attributeName(DynamoDbConfigurationSource.defaultKeyAttribute)
+                .keyType(KeyType.HASH)
+                .build();
 
-        ProvisionedThroughput provisionedThroughput = new ProvisionedThroughput()
-                .withReadCapacityUnits(1L)
-                .withWriteCapacityUnits(1L);
+        ProvisionedThroughput provisionedThroughput = ProvisionedThroughput.builder()
+                .readCapacityUnits(1L)
+                .writeCapacityUnits(1L)
+                .build();
 
-        dbClient.createTable(new CreateTableRequest().withTableName(tableName)
-                .withKeySchema(hashKey).withProvisionedThroughput(provisionedThroughput));
+        dbClient.createTable(CreateTableRequest.builder().tableName(tableName)
+                .keySchema(hashKey).provisionedThroughput(provisionedThroughput).build());
 
-        while (!dbClient.describeTable(new DescribeTableRequest().withTableName(tableName)).getTable().getTableStatus().equalsIgnoreCase("active")) {
+        while (!dbClient.describeTable(DescribeTableRequest.builder().tableName(tableName).build()).table().tableStatus().name().equalsIgnoreCase("active")) {
             Thread.sleep(10000);
         }
     }
 
-    static void addElements(AmazonDynamoDB dbClient, String tableName) {
+    static void addElements(DynamoDbClient dbClient, String tableName) {
         Map<String, List<WriteRequest>> requestMap = new HashMap<String, List<WriteRequest>>(1);
         List<WriteRequest> writeList = new ArrayList<WriteRequest>(3);
 
         Map<String, AttributeValue> item1 = new HashMap<String, AttributeValue>(1);
-        item1.put(DynamoDbConfigurationSource.defaultKeyAttribute, new AttributeValue().withS("test1"));
-        item1.put(DynamoDbConfigurationSource.defaultValueAttribute, new AttributeValue().withS("val1"));
-        writeList.add(new WriteRequest().withPutRequest(new PutRequest().withItem(item1)));
+        item1.put(DynamoDbConfigurationSource.defaultKeyAttribute, AttributeValue.builder().s("test1").build());
+        item1.put(DynamoDbConfigurationSource.defaultValueAttribute, AttributeValue.builder().s("val1").build());
+        writeList.add(WriteRequest.builder().putRequest(PutRequest.builder().item(item1).build()).build());
 
         HashMap<String, AttributeValue> item2 = new HashMap<String, AttributeValue>(1);
-        item2.put(DynamoDbConfigurationSource.defaultKeyAttribute, new AttributeValue().withS("test2"));
-        item2.put(DynamoDbConfigurationSource.defaultValueAttribute, new AttributeValue().withS("val2"));
-        writeList.add(new WriteRequest().withPutRequest(new PutRequest().withItem(item2)));
+        item2.put(DynamoDbConfigurationSource.defaultKeyAttribute, AttributeValue.builder().s("test2").build());
+        item2.put(DynamoDbConfigurationSource.defaultValueAttribute, AttributeValue.builder().s("val2").build());
+        writeList.add(WriteRequest.builder().putRequest(PutRequest.builder().item(item2).build()).build());
 
         HashMap<String, AttributeValue> item3 = new HashMap<String, AttributeValue>(1);
-        item3.put(DynamoDbConfigurationSource.defaultKeyAttribute, new AttributeValue().withS("test3"));
-        item3.put(DynamoDbConfigurationSource.defaultValueAttribute, new AttributeValue().withS("val3"));
-        writeList.add(new WriteRequest().withPutRequest(new PutRequest().withItem(item3)));
+        item3.put(DynamoDbConfigurationSource.defaultKeyAttribute, AttributeValue.builder().s("test3").build());
+        item3.put(DynamoDbConfigurationSource.defaultValueAttribute, AttributeValue.builder().s("val3").build());
+        writeList.add(WriteRequest.builder().putRequest(PutRequest.builder().item(item3).build()).build());
 
         requestMap.put(tableName, writeList);
 
-        BatchWriteItemRequest request = new BatchWriteItemRequest().withRequestItems(requestMap);
+        BatchWriteItemRequest request = BatchWriteItemRequest.builder().requestItems(requestMap).build();
         dbClient.batchWriteItem(request);
     }
 
-    static void updateValues(AmazonDynamoDB dbClient, String tableName) {
+    static void updateValues(DynamoDbClient dbClient, String tableName) {
 
         Map<String, AttributeValue> key1 = new HashMap<String, AttributeValue>(1);
-        key1.put("test1", new AttributeValue().withS("HASH"));
+        key1.put("test1", AttributeValue.builder().s("HASH").build());
 
         Map<String, AttributeValueUpdate> item1 = new HashMap<String, AttributeValueUpdate>(1);
-        item1.put(DynamoDbConfigurationSource.defaultValueAttribute, new AttributeValueUpdate()
-                .withAction(AttributeAction.PUT).withValue(new AttributeValue().withS("vala")));
+        item1.put(DynamoDbConfigurationSource.defaultValueAttribute, AttributeValueUpdate.builder()
+                .action(AttributeAction.PUT).value(AttributeValue.builder().s("vala").build()).build());
 
-        dbClient.updateItem(new UpdateItemRequest().withTableName(tableName).
-                withKey(key1).withAttributeUpdates(item1));
+        dbClient.updateItem(UpdateItemRequest.builder().tableName(tableName).key(key1).attributeUpdates(item1).build());
 
         Map<String, AttributeValue> key2 = new HashMap<String, AttributeValue>(1);
-        key2.put("test2", new AttributeValue().withS("HASH"));
+        key2.put("test2", AttributeValue.builder().s("HASH").build());
 
         HashMap<String, AttributeValueUpdate> item2 = new HashMap<String, AttributeValueUpdate>(1);
-        item2.put(DynamoDbConfigurationSource.defaultValueAttribute, new AttributeValueUpdate()
-                .withAction(AttributeAction.PUT).withValue(new AttributeValue().withS("valb")));
+        item2.put(DynamoDbConfigurationSource.defaultValueAttribute, AttributeValueUpdate.builder()
+                .action(AttributeAction.PUT).value(AttributeValue.builder().s("valb").build()).build());
 
-        dbClient.updateItem(new UpdateItemRequest().withTableName(tableName).
-                withKey(key2).withAttributeUpdates(item2));
+        dbClient.updateItem(UpdateItemRequest.builder().tableName(tableName).key(key2).attributeUpdates(item2).build());
 
         Map<String, AttributeValue> key3 = new HashMap<String, AttributeValue>(1);
-        key3.put("test3", new AttributeValue().withS("HASH"));
+        key3.put("test3", AttributeValue.builder().s("HASH").build());
 
         HashMap<String, AttributeValueUpdate> item3 = new HashMap<String, AttributeValueUpdate>(1);
-        item3.put(DynamoDbConfigurationSource.defaultValueAttribute, new AttributeValueUpdate()
-                .withAction(AttributeAction.PUT).withValue(new AttributeValue().withS("valc")));
+        item3.put(DynamoDbConfigurationSource.defaultValueAttribute, AttributeValueUpdate.builder()
+                .action(AttributeAction.PUT).value(AttributeValue.builder().s("valc").build()).build());
 
-        dbClient.updateItem(new UpdateItemRequest().withTableName(tableName).
-                withKey(key3).withAttributeUpdates(item3));
+        dbClient.updateItem(UpdateItemRequest.builder().tableName(tableName).key(key3).attributeUpdates(item3).build());
     }
 
-    static void removeTable(AmazonDynamoDB dbClient, String tableName) {
+    static void removeTable(DynamoDbClient dbClient, String tableName) {
         //TODO check to make sure the table isn't being created or deleted.
         if (dbClient != null) {
-            dbClient.deleteTable(new DeleteTableRequest().withTableName(tableName));
+            dbClient.deleteTable(DeleteTableRequest.builder().tableName(tableName).build());
         }
     }
 }

--- a/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbMocks.java
+++ b/archaius-aws/src/test/java/com/netflix/config/sources/DynamoDbMocks.java
@@ -15,8 +15,8 @@
  */
 package com.netflix.config.sources;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ScanResult;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,65 +38,65 @@ public class DynamoDbMocks {
 
     public static final Collection<Map<String, AttributeValue>> basicResultValues1 = new LinkedList<Map<String, AttributeValue>>();
     public static final Collection<Map<String, AttributeValue>> basicResultValues2 = new LinkedList<Map<String, AttributeValue>>();
-    public static final ScanResult basicScanResult1;
-    public static final ScanResult basicScanResult2;
+    public static final ScanResponse basicScanResult1;
+    public static final ScanResponse basicScanResult2;
 
     public static final Collection<Map<String, AttributeValue>> contextResultValues1 = new LinkedList<Map<String, AttributeValue>>();
     public static final Collection<Map<String, AttributeValue>> contextResultValues2 = new LinkedList<Map<String, AttributeValue>>();
-    public static final ScanResult contextScanResult1;
-    public static final ScanResult contextScanResult2;
+    public static final ScanResponse contextScanResult1;
+    public static final ScanResponse contextScanResult2;
 
 
     static {
         //Basic results config
         Map<String, AttributeValue> basicRow1 = new HashMap<String, AttributeValue>();
-        basicRow1.put(defaultKeyAttribute, new AttributeValue().withS("foo"));
-        basicRow1.put(defaultValueAttribute, new AttributeValue().withS("bar"));
+        basicRow1.put(defaultKeyAttribute, AttributeValue.builder().s("foo").build());
+        basicRow1.put(defaultValueAttribute, AttributeValue.builder().s("bar").build());
         basicResultValues1.add(basicRow1);
 
         Map<String, AttributeValue> basicRow2 = new HashMap<String, AttributeValue>();
-        basicRow2.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
-        basicRow2.put(defaultValueAttribute, new AttributeValue().withS("goo"));
+        basicRow2.put(defaultKeyAttribute, AttributeValue.builder().s("goo").build());
+        basicRow2.put(defaultValueAttribute, AttributeValue.builder().s("goo").build());
         basicResultValues1.add(basicRow2);
 
         Map<String, AttributeValue> basicRow3 = new HashMap<String, AttributeValue>();
-        basicRow3.put(defaultKeyAttribute, new AttributeValue().withS("boo"));
-        basicRow3.put(defaultValueAttribute, new AttributeValue().withS("who"));
+        basicRow3.put(defaultKeyAttribute, AttributeValue.builder().s("boo").build());
+        basicRow3.put(defaultValueAttribute, AttributeValue.builder().s("who").build());
         basicResultValues1.add(basicRow3);
 
         //Result2
         Map<String, AttributeValue> updatedBasicRow = new HashMap<String, AttributeValue>();
-        updatedBasicRow.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
-        updatedBasicRow.put(defaultValueAttribute, new AttributeValue().withS("foo"));
+        updatedBasicRow.put(defaultKeyAttribute, AttributeValue.builder().s("goo").build());
+        updatedBasicRow.put(defaultValueAttribute, AttributeValue.builder().s("foo").build());
         basicResultValues2.add(updatedBasicRow);
 
         basicResultValues2.add(basicRow1);
         basicResultValues2.add(updatedBasicRow);
         basicResultValues2.add(basicRow3);
 
-        basicScanResult1 = new ScanResult().withItems(basicResultValues1).withLastEvaluatedKey(null);
-        basicScanResult2 = new ScanResult().withItems(basicResultValues2).withLastEvaluatedKey(null);
+        basicScanResult1 = ScanResponse.builder().items(basicResultValues1).lastEvaluatedKey(null).build();
+        basicScanResult2 = ScanResponse.builder().items(basicResultValues2).lastEvaluatedKey(null).build();
 
         //DeploymentContext results config
         Map<String, AttributeValue> contextRow1 = new HashMap<String, AttributeValue>();
-        contextRow1.put(defaultKeyAttribute, new AttributeValue().withS("foo"));
-        contextRow1.put(defaultValueAttribute, new AttributeValue().withS("bar"));
-        contextRow1.put(defaultContextKeyAttribute, new AttributeValue().withS("environment"));
-        contextRow1.put(defaultContextValueAttribute, new AttributeValue().withS("test"));
+        contextRow1.put(defaultKeyAttribute, AttributeValue.builder().s("foo").build());
+        contextRow1.put(defaultValueAttribute, AttributeValue.builder().s("bar").build());
+        contextRow1.put(defaultContextKeyAttribute, AttributeValue.builder().s("environment").build());
+        contextRow1.put(defaultContextValueAttribute, AttributeValue.builder().s("test").build());
         contextResultValues1.add(contextRow1);
 
         Map<String, AttributeValue> contextRow2 = new HashMap<String, AttributeValue>();
-        contextRow2.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
-        contextRow2.put(defaultValueAttribute, new AttributeValue().withS("goo"));
-        contextRow2.put(defaultContextKeyAttribute, new AttributeValue().withS("environment"));
-        contextRow2.put(defaultContextValueAttribute, new AttributeValue().withS("test"));
+        contextRow2.put(defaultKeyAttribute, AttributeValue.builder().s("goo").build());
+        contextRow2.put(defaultValueAttribute, AttributeValue.builder().s("goo").build());
+        contextRow2.put(defaultContextKeyAttribute, AttributeValue.builder().s("environment").build());
+        contextRow2.put(defaultContextValueAttribute, AttributeValue.builder().s("test").build());
         contextResultValues1.add(contextRow2);
 
         Map<String, AttributeValue> contextRow3 = new HashMap<String, AttributeValue>();
-        contextRow3.put(defaultKeyAttribute, new AttributeValue().withS("boo"));
-        contextRow3.put(defaultValueAttribute, new AttributeValue().withS("who"));
-        contextRow3.put(defaultContextKeyAttribute, new AttributeValue().withS("environment"));
-        contextRow3.put(defaultContextValueAttribute, new AttributeValue().withS("test"));
+        contextRow3.put(defaultKeyAttribute, AttributeValue.builder().s("boo").build());
+        contextRow3.put(defaultValueAttribute, AttributeValue.builder().s("who").build());
+        contextRow3.put(defaultContextKeyAttribute, AttributeValue.builder().s("environment").build());
+        contextRow3.put(defaultContextValueAttribute, AttributeValue.builder().s("test").build());
         contextResultValues1.add(contextRow3);
 
         contextResultValues1.add(basicRow1);
@@ -106,23 +106,23 @@ public class DynamoDbMocks {
         contextResultValues2.add(contextRow3);
 
         Map<String, AttributeValue> contextRow4 = new HashMap<String, AttributeValue>();
-        contextRow4.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
-        contextRow4.put(defaultValueAttribute, new AttributeValue().withS("foo"));
-        contextRow4.put(defaultContextKeyAttribute, new AttributeValue().withS("environment"));
-        contextRow4.put(defaultContextValueAttribute, new AttributeValue().withS("prod"));
+        contextRow4.put(defaultKeyAttribute, AttributeValue.builder().s("goo").build());
+        contextRow4.put(defaultValueAttribute, AttributeValue.builder().s("foo").build());
+        contextRow4.put(defaultContextKeyAttribute, AttributeValue.builder().s("environment").build());
+        contextRow4.put(defaultContextValueAttribute, AttributeValue.builder().s("prod").build());
         contextResultValues2.add(contextRow4);
 
         Map<String, AttributeValue> updatedContextRow = new HashMap<String, AttributeValue>();
-        updatedContextRow.put(defaultKeyAttribute, new AttributeValue().withS("goo"));
-        updatedContextRow.put(defaultValueAttribute, new AttributeValue().withS("foo"));
-        updatedContextRow.put(defaultContextKeyAttribute, new AttributeValue().withS("environment"));
-        updatedContextRow.put(defaultContextValueAttribute, new AttributeValue().withS("test"));
+        updatedContextRow.put(defaultKeyAttribute, AttributeValue.builder().s("goo").build());
+        updatedContextRow.put(defaultValueAttribute, AttributeValue.builder().s("foo").build());
+        updatedContextRow.put(defaultContextKeyAttribute, AttributeValue.builder().s("environment").build());
+        updatedContextRow.put(defaultContextValueAttribute, AttributeValue.builder().s("test").build());
         contextResultValues2.add(updatedContextRow);
 
         contextResultValues2.add(basicRow1);
 
         //Create results from initialized values
-        contextScanResult1 = new ScanResult().withItems(contextResultValues1);
-        contextScanResult2 = new ScanResult().withItems(contextResultValues2);
+        contextScanResult1 = ScanResponse.builder().items(contextResultValues1).lastEvaluatedKey(null).build();
+        contextScanResult2 = ScanResponse.builder().items(contextResultValues2).lastEvaluatedKey(null).build();
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     repositories {
         jcenter()
@@ -42,7 +42,6 @@ subprojects {
 
     tasks.withType(Test) { forkEvery = 1 }
     test {
-        jvmArgs += [ "-XX:MaxPermSize=512m" ] // for archaius-scala
         maxHeapSize = '2g' // or however much memory the tests need
         testLogging {
             events 'started', 'failed', 'passed', 'skipped'
@@ -94,9 +93,8 @@ project(':archaius-core') {
 project(':archaius-aws') {
     dependencies {
         compile project(':archaius-core')
-        compile 'com.amazonaws:aws-java-sdk-core:1.9.3'
-        compile 'com.amazonaws:aws-java-sdk-dynamodb:1.9.3'
-        compile 'com.amazonaws:aws-java-sdk-s3:1.9.3'
+        compile("software.amazon.awssdk:dynamodb:2.29.17")
+        compile("software.amazon.awssdk:s3:2.29.17")
         testCompile 'junit:junit:4.11'
         testCompile 'org.mockito:mockito-all:1.9.5'
         testCompile 'org.slf4j:slf4j-simple:1.6.4'


### PR DESCRIPTION
**What**:
Switching the `archaius-aws` from AWS SDK v1 to v2.
Which in turn required to bump the Java version to 8.

**Why**:
AWS SDK v1 is about to go EOL: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/

**Testing performed**
- `./gradlew archaius-aws:test`
- ... incl. temporarily enabling the 3 integration tests marked with ` @Test // disabled as it requires additional setup`
